### PR TITLE
Potential fix for code scanning alert no. 2: Flask app is run in debug mode

### DIFF
--- a/server/run.py
+++ b/server/run.py
@@ -1,6 +1,8 @@
 from app import create_app
+import os
 
 app = create_app()
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    debug_mode = os.getenv('FLASK_DEBUG', 'False').lower() in ['true', '1', 't']
+    app.run(debug=debug_mode)


### PR DESCRIPTION
Potential fix for [https://github.com/ryan-dev-flat/patent/security/code-scanning/2](https://github.com/ryan-dev-flat/patent/security/code-scanning/2)

To fix the problem, we need to ensure that the Flask application does not run in debug mode in a production environment. The best way to achieve this is to control the debug mode using an environment variable. This way, we can set the debug mode to `True` during development and `False` during production without changing the code.

1. Modify the `app.run(debug=True)` line to use an environment variable to determine the debug mode.
2. Import the `os` module to access environment variables.
3. Set the default value of the debug mode to `False` to ensure it is secure by default.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
